### PR TITLE
Adds lazy loading to defer loading of slow AudioSet import

### DIFF
--- a/distil/primitives/audio_transfer.py
+++ b/distil/primitives/audio_transfer.py
@@ -12,13 +12,14 @@ import numpy as np
 from PIL import Image
 
 from distil.modeling.metrics import classification_metrics, regression_metrics
-
-
-from distil.modeling.pretrained_audio import AudiosetModel
+from distil.primitives import utils as primitive_utils
 
 __all__ = ('AudioTransferPrimitive',)
 
 logger = logging.getLogger(__name__)
+
+# lazy load pretrained audio due to lengthy import time
+pretrained_audio = utils.lazy_load("distil.modeling.pretrained_audio")
 
 class Hyperparams(hyperparams.Hyperparams):
     use_columns = hyperparams.Set(
@@ -102,7 +103,7 @@ class AudioTransferPrimitive(unsupervised_learning.UnsupervisedLearnerPrimitiveB
 
         PrimitiveBase.__init__(self, hyperparams=hyperparams, random_seed=random_seed, volumes=volumes)
         self.volumes = volumes
-        self.audio_set = AudiosetModel(model_path=self.volumes["vggish_model"])
+        self.audio_set = pretrained_audio.AudiosetModel(model_path=self.volumes["vggish_model"])
 
     def __getstate__(self) -> dict:
         state = PrimitiveBase.__getstate__(self)

--- a/distil/primitives/utils.py
+++ b/distil/primitives/utils.py
@@ -1,5 +1,8 @@
 import io
 from typing import Sequence
+import sys
+import importlib.util
+import importlib.machinery
 
 import numpy as np
 
@@ -48,3 +51,16 @@ def get_operating_columns_structural_type(inputs: container.DataFrame, use_colum
     else:
         cols = type_cols
     return list(cols)
+
+def lazy_load(fullname: str):
+    # lazy load a module - needed for imports that trigger long running static model
+    # loads
+    if fullname in sys.modules:
+        return sys.modules[fullname]
+    else:
+        spec = importlib.util.find_spec(fullname)
+        module = importlib.util.module_from_spec(spec)
+        loader = importlib.util.LazyLoader(spec.loader)
+        # Make module with proper locking and get it inserted into sys.modules.
+        loader.exec_module(module)
+        return module


### PR DESCRIPTION
Fixes #36.  AudioSet import ends up triggering a load of pre-trained models that take on the order of minutes to initialize.  This impacts the start up time of TA2s in certain circumstances, so we now lazy load AudioSet, deferring its import until it is actually used in a pipeline execution.