### PR TITLE
Adds default metrics where missing

### DIFF
--- a/distil/primitives/link_prediction.py
+++ b/distil/primitives/link_prediction.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class Hyperparams(hyperparams.Hyperparams):
     metric = hyperparams.Hyperparameter[str](
-        default='',
+        default='accuracy',
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
     )
 

--- a/distil/primitives/seeded_graph_matching.py
+++ b/distil/primitives/seeded_graph_matching.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class Hyperparams(hyperparams.Hyperparams):
     metric = hyperparams.Hyperparameter[str](
-        default='',
+        default='accuracy',
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
     )
 

--- a/distil/primitives/text_classifier.py
+++ b/distil/primitives/text_classifier.py
@@ -33,7 +33,7 @@ class Hyperparams(hyperparams.Hyperparams):
         description="A set of column indices to force primitive to operate on. If any specified column cannot be parsed, it is skipped.",
     )
     metric = hyperparams.Hyperparameter[str](
-        default='',
+        default='f1',
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
     )
     fast = hyperparams.Hyperparameter[bool](


### PR DESCRIPTION
Fixes #41.  Leaving metric with an empty string for a default causes the primitive to fail.