### PR TITLE
Feature/remove columns by semantic type

### DIFF
--- a/distil/primitives/remove_columns_by_semantic_types.py
+++ b/distil/primitives/remove_columns_by_semantic_types.py
@@ -1,0 +1,214 @@
+import os
+import typing
+from distil.utils import CYTHON_DEP
+from d3m import container, exceptions, utils as d3m_utils
+from d3m.base import utils as base_utils
+from d3m.metadata import base as metadata_base, hyperparams
+from d3m.primitive_interfaces import base, transformer
+import common_primitives
+
+__all__ = ("ExtractColumnsBySemanticTypesPrimitive",)
+
+Inputs = container.DataFrame
+Outputs = container.DataFrame
+
+
+class Hyperparams(hyperparams.Hyperparams):
+    semantic_types = hyperparams.Set(
+        elements=hyperparams.Hyperparameter[str](""),
+        default=("https://metadata.datadrivendiscovery.org/types/Attribute",),
+        min_size=1,
+        semantic_types=[
+            "https://metadata.datadrivendiscovery.org/types/ControlParameter"
+        ],
+        description="Semantic types to use to extract columns. If any of them matches, by default.",
+    )
+    match_logic = hyperparams.Enumeration(
+        values=["set", "all", "any"],
+        default="set",
+        semantic_types=[
+            "https://metadata.datadrivendiscovery.org/types/ControlParameter"
+        ],
+        description='Should a column have all of semantic types in "semantic_types" to be extracted, or any of them?',
+    )
+    negate = hyperparams.UniformBool(
+        default=False,
+        semantic_types=[
+            "https://metadata.datadrivendiscovery.org/types/ControlParameter"
+        ],
+        description='Should columns which do not match semantic types in "semantic_types" be extracted?',
+    )
+    use_columns = hyperparams.Set(
+        elements=hyperparams.Hyperparameter[int](-1),
+        default=(),
+        semantic_types=[
+            "https://metadata.datadrivendiscovery.org/types/ControlParameter"
+        ],
+        description="A set of column indices to force primitive to operate on. If any specified column does not match any semantic type, it is skipped.",
+    )
+    exclude_columns = hyperparams.Set(
+        elements=hyperparams.Hyperparameter[int](-1),
+        default=(),
+        semantic_types=[
+            "https://metadata.datadrivendiscovery.org/types/ControlParameter"
+        ],
+        description='A set of column indices to not operate on. Applicable only if "use_columns" is not provided.',
+    )
+    add_index_columns = hyperparams.UniformBool(
+        default=False,
+        semantic_types=[
+            "https://metadata.datadrivendiscovery.org/types/ControlParameter"
+        ],
+        description="Also include primary index columns if input data has them.",
+    )
+
+
+class RemoveColumnsBySemanticTypesPrimitive(
+    transformer.TransformerPrimitiveBase[Inputs, Outputs, Hyperparams]
+):
+    """
+    A primitive which extracts columns from input data based on semantic types provided.
+    Columns which match any of the listed semantic types are extracted.
+
+    If you want to extract only attributes, you can use ``https://metadata.datadrivendiscovery.org/types/Attribute``
+    semantic type (also default).
+
+    For real targets (not suggested targets) use ``https://metadata.datadrivendiscovery.org/types/Target``.
+    For this to work, columns have to be are marked as targets by the TA2 in a dataset before passing the dataset
+    through a pipeline. Or something else has to mark them at some point in a pipeline.
+
+    It uses ``use_columns`` and ``exclude_columns`` to control which columns it considers.
+    """
+
+    metadata = metadata_base.PrimitiveMetadata(
+        {
+            "id": "a91a043d-a014-49da-b65b-eaa4fed72130",
+            "version": "0.1.0",
+            "name": "Delete columns by semantic type",
+            "python_path": "d3m.primitives.data_transformation.remove_columns_by_semantic_types.RemoveColumnsBySemanticTypesPrimitive",
+            "source": {
+                "name": common_primitives.__author__,
+                "contact": "mailto:balazs.horanyi@qntfy.com",
+                "uris": [
+                    "https://github.com/uncharted-distil/distil-primitives/distil/primitives/remove_columns_by_semantic_type.py",
+                    "https://github.com/uncharted-distil/distil-primitives",
+                ],
+            },
+            "installation": [
+                CYTHON_DEP,
+                {
+                    "type": metadata_base.PrimitiveInstallationType.PIP,
+                    "package_uri": "git+https://github.com/uncharted-distil/distil-primitives.git@{git_commit}#egg=distil-primitives".format(
+                        git_commit=d3m_utils.current_git_commit(os.path.dirname(__file__)),
+                    ),
+                },
+            ],
+            "algorithm_types": [metadata_base.PrimitiveAlgorithmType.ARRAY_SLICING, ],
+            "primitive_family": metadata_base.PrimitiveFamily.DATA_TRANSFORMATION,
+        },
+    )
+
+    def produce(
+            self, *, inputs: Inputs, timeout: float = None, iterations: int = None
+    ) -> base.CallResult[Outputs]:
+        columns_to_remove = self._get_columns(inputs.metadata, self.hyperparams)
+
+        outputs = inputs.remove_columns(columns_to_remove)
+
+        return base.CallResult(outputs)
+
+    @classmethod
+    def _can_use_column(
+            cls,
+            inputs_metadata: metadata_base.DataMetadata,
+            column_index: int,
+            hyperparams: Hyperparams,
+    ) -> bool:
+        column_metadata = inputs_metadata.query(
+            (metadata_base.ALL_ELEMENTS, column_index)
+        )
+
+        semantic_types = column_metadata.get("semantic_types", [])
+
+        if hyperparams["match_logic"] == "set":
+            match = len(set(semantic_types) - set(hyperparams["semantic_types"])) == 0
+
+        elif hyperparams["match_logic"] == "all":
+            match = all(
+                semantic_type in semantic_types
+                for semantic_type in hyperparams["semantic_types"]
+            )
+        elif hyperparams["match_logic"] == "any":
+            match = any(
+                semantic_type in semantic_types
+                for semantic_type in hyperparams["semantic_types"]
+            )
+        else:
+            raise exceptions.UnexpectedValueError(
+                'Unknown value of hyper-parameter "match_logic": {value}'.format(
+                    value=hyperparams["match_logic"]
+                )
+            )
+
+        if hyperparams["negate"]:
+            return not match
+        else:
+            return match
+
+    @classmethod
+    def _get_columns(
+            cls, inputs_metadata: metadata_base.DataMetadata, hyperparams: Hyperparams
+    ) -> typing.Sequence[int]:
+        def can_use_column(column_index: int) -> bool:
+            return cls._can_use_column(inputs_metadata, column_index, hyperparams)
+
+        columns_to_use, columns_not_to_use = base_utils.get_columns_to_use(
+            inputs_metadata,
+            hyperparams["use_columns"],
+            hyperparams["exclude_columns"],
+            can_use_column,
+        )
+
+        if hyperparams["use_columns"] and columns_not_to_use:
+            cls.logger.warning(
+                "Not all specified columns match semantic types. Skipping columns: %(columns)s",
+                {"columns": columns_not_to_use, },
+            )
+
+        return columns_to_use
+
+    @classmethod
+    def can_accept(
+            cls,
+            *,
+            method_name: str,
+            arguments: typing.Dict[str, typing.Union[metadata_base.Metadata, type]],
+            hyperparams: Hyperparams
+    ) -> typing.Optional[metadata_base.DataMetadata]:
+        output_metadata = super().can_accept(
+            method_name=method_name, arguments=arguments, hyperparams=hyperparams
+        )
+
+        # If structural types didn't match, don't bother.
+        if output_metadata is None:
+            return None
+
+        if method_name != "produce":
+            return output_metadata
+
+        if "inputs" not in arguments:
+            return output_metadata
+
+        inputs_metadata = typing.cast(metadata_base.DataMetadata, arguments["inputs"])
+
+        columns_to_use = cls._get_columns(inputs_metadata, hyperparams)
+
+        output_columns = inputs_metadata.select_columns(columns_to_use)
+
+        return base_utils.combine_columns_metadata(
+            inputs_metadata,
+            columns_to_use,
+            [output_columns],
+            return_result="new",
+            add_index_columns=hyperparams["add_index_columns"],
+        )

--- a/distil/primitives/text_encoder.py
+++ b/distil/primitives/text_encoder.py
@@ -22,6 +22,14 @@ Outputs = container.DataFrame
 
 
 class Hyperparams(hyperparams.Hyperparams):
+    metric = hyperparams.Hyperparameter[str](
+        default="f1Macro",
+        semantic_types=[
+            "https://metadata.datadrivendiscovery.org/types/ControlParameter"
+        ],
+        description="The D3M scoring metric to use during the fit phase.  This can be any of the regression, classification or "
+                    + "clustering metrics.",
+    )
     use_columns = hyperparams.Set(
         elements=hyperparams.Hyperparameter[int](-1),
         default=(),
@@ -75,7 +83,7 @@ class TextEncoderPrimitive(base.PrimitiveBase[Inputs, Outputs, Params, Hyperpara
     def __init__(self, *,
                  hyperparams: Hyperparams,
                  random_seed: int = 0) -> None:
-        super().__init__(hyperparams=hyperparams, random_seed=random_seed)
+        base.PrimitiveBase.__init__(self, hyperparams=hyperparams, random_seed=random_seed)
 
     def __getstate__(self) -> dict:
         state = base.PrimitiveBase.__getstate__(self)
@@ -112,7 +120,7 @@ class TextEncoderPrimitive(base.PrimitiveBase[Inputs, Outputs, Params, Hyperpara
 
         for i, c in enumerate(self._cols):
             if self.hyperparams['encoder_type'] == 'svm':
-                self._encoders.append(SVMTextEncoder())
+                self._encoders.append(SVMTextEncoder(self.hyperparams["metric"]))
             elif self.hyperparams['encoder_type'] == 'tfidf':
                 self._encoders.append(TfidifEncoder())
             else:

--- a/distil/primitives/text_encoder.py
+++ b/distil/primitives/text_encoder.py
@@ -83,7 +83,7 @@ class TextEncoderPrimitive(base.PrimitiveBase[Inputs, Outputs, Params, Hyperpara
     def __init__(self, *,
                  hyperparams: Hyperparams,
                  random_seed: int = 0) -> None:
-        base.PrimitiveBase.__init__(self, hyperparams=hyperparams, random_seed=random_seed)
+        super().__init__(hyperparams=hyperparams, random_seed=random_seed)
 
     def __getstate__(self) -> dict:
         state = base.PrimitiveBase.__getstate__(self)

--- a/distil/primitives/utils.py
+++ b/distil/primitives/utils.py
@@ -14,7 +14,8 @@ SINGLETON_INDICATOR     = '__sing_salt_6df854b8-a0ba-41ba-b598-ddeba2edfb53'
 
 CATEGORICALS = ('https://metadata.datadrivendiscovery.org/types/CategoricalData',
                 'https://metadata.datadrivendiscovery.org/types/OrdinalData',
-                'http://schema.org/DateTime')
+                'http://schema.org/DateTime',
+                'http://schema.org/Boolean')
 
 VECTOR = ('https://metadata.datadrivendiscovery.org/types/FloatVector')
 

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
             'data_transformation.data_cleaning.OutputDataframe = distil.primitives.output_dataframe:OutputDataframePrimitive',
             'feature_selection.mutual_info_classif.DistilMIRanking = distil.primitives.mi_ranking:MIRankingPrimitive',
             'data_transformation.list_to_dataframe.DistilListEncoder = distil.primitives.list_to_dataframe:ListEncoderPrimitive',
+            'data_transformation.remove_columns_by_semantic_types.RemoveColumnsBySemanticTypesPrimitive= distil.primitives.remove_columns_by_semantic_types:RemoveColumnsBySemanticTypesPrimitive'
         ],
     }
 )


### PR DESCRIPTION
Profilers aren't guaranteed to tag every column, this can give attribute columns with no semantic types which tend to act oddly and break downstream tasks. Added a new primitive that copies the `extract_columns_by_semantic_type` to remove columns by semantic types. 
Forgot to change branches from the text encoder work, so can clean that up if need be. 