### PR TITLE
Binary Encode Single Row

### DIFF
--- a/distil/preprocessing/transformers.py
+++ b/distil/preprocessing/transformers.py
@@ -34,7 +34,11 @@ class BinaryEncoder(BaseEstimator, TransformerMixin):
 
     def transform(self, X, y=None):
         assert self.lookup is not None
-        return np.vstack([self.lookup.get(xx, self.lookup[MISSING_VALUE_INDICATOR]) for xx in X.squeeze()])
+        squeezed = X.squeeze()
+        # single row element will become scalar after squeeze
+        if not isinstance(squeezed, pd.Series):
+            squeezed = [squeezed]
+        return np.vstack([self.lookup.get(xx, self.lookup[MISSING_VALUE_INDICATOR]) for xx in squeezed])
 
     def fit_transform(self, X, y=None, **kwargs):
         _ = self.fit(X)

--- a/test/tabular_dataset_2/datasetDoc.json
+++ b/test/tabular_dataset_2/datasetDoc.json
@@ -10,61 +10,47 @@
   },
   "dataResources": [
     {
-      "resID": "0",
+      "resID": "learningData",
       "resPath": "tables/learningData.csv",
       "resType": "table",
-      "resFormat": [
-        "text/csv"
-      ],
+      "resFormat": ["text/csv"],
       "isCollection": false,
       "columns": [
         {
           "colIndex": 0,
           "colName": "d3mIndex",
           "colType": "integer",
-          "role": [
-            "index"
-          ]
+          "role": ["index"]
         },
         {
           "colIndex": 1,
           "colName": "alpha",
           "colType": "categorical",
-          "role": [
-            "attribute"
-          ]
+          "role": ["attribute"]
         },
         {
           "colIndex": 2,
           "colName": "bravo",
           "colType": "real",
-          "role": [
-            "attribute"
-          ]
+          "role": ["attribute"]
         },
         {
           "colIndex": 3,
           "colName": "charlie",
           "colType": "boolean",
-          "role": [
-            "attribute"
-          ]
+          "role": ["attribute"]
         },
         {
           "colIndex": 4,
           "colName": "delta",
           "colType": "string",
-          "role": [
-            "attribute"
-          ]
+          "role": ["attribute"]
         },
         {
           "colIndex": 5,
           "colName": "echo",
           "colType": "integer",
-          "role": [
-            "attribute"
-          ]
+          "role": ["attribute"]
         }
       ]
     }

--- a/test/test_binary_encoder.py
+++ b/test/test_binary_encoder.py
@@ -1,0 +1,50 @@
+"""
+   Copyright © 2019 Uncharted Software Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+import unittest
+from os import path
+import sys
+
+from d3m import container
+
+from d3m.metadata import base as metadata_base
+from distil.primitives.binary_encoder import BinaryEncoderPrimitive
+from distil.primitives import utils
+import utils as test_utils
+
+class BinaryEncoderPrimitiveTestCase(unittest.TestCase):
+
+    _dataset_path = path.abspath(path.join(path.dirname(__file__), 'tabular_dataset'))
+
+    def test_single_row(self) -> None:
+        # load test data into a dataframe
+        dataset = test_utils.load_dataset(self._dataset_path)
+        dataframe = test_utils.get_dataframe(dataset, 'learningData')
+
+        # create the imputer
+        hyperparams_class = \
+            BinaryEncoderPrimitive.metadata.query()['primitive_code']['class_type_arguments']['Hyperparams']
+        encoder = BinaryEncoderPrimitive(hyperparams=hyperparams_class.defaults().replace({
+            "min_binary": 3
+        }))
+
+        encoder.set_training_data(inputs=dataframe)
+        encoder.fit()
+        result = encoder.produce(inputs=dataframe.head(1)).value
+        self.assertEqual(len(result.index), 1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_mi_ranking.py
+++ b/test/test_mi_ranking.py
@@ -111,7 +111,7 @@ class MIRankingPrimitiveTestCase(unittest.TestCase):
 
         # load the dataset and convert resource 0 to a dataframe
         dataset = container.Dataset.load('file://{dataset_doc_path}'.format(dataset_doc_path=dataset_doc_path))
-        dataframe = dataset['0']
+        dataframe = dataset['learningData']
         dataframe.metadata = dataframe.metadata.generate(dataframe)
 
         # set the struct type


### PR DESCRIPTION
Fixed an issue with the binary encoder when it was producing on a single row of data. The transformer squeezes the input data and then iterates over the resulting series to map input values to transformed valued. However, if only a single row of data exists, the squeeze operation will result in a scalar instead of a series. This fix wraps the resulting scalar into a list to be iterated over as before.