### PR TITLE
ensures the number of folds doesn't exceed the number of classes

### DIFF
--- a/distil/preprocessing/transformers.py
+++ b/distil/preprocessing/transformers.py
@@ -49,6 +49,11 @@ class BinaryEncoder(BaseEstimator, TransformerMixin):
 # Text
 
 class SVMTextEncoder(BaseEstimator, TransformerMixin):
+    # number of jobs to execute in parallel
+    NUM_JOBS=3
+    # number of folds to apply to svm fit
+    NUM_FOLDS=3
+
     # !! add tuning
     def __init__(self, metric):
         super().__init__()
@@ -86,13 +91,17 @@ class SVMTextEncoder(BaseEstimator, TransformerMixin):
         assert y is not None, 'SVMTextEncoder.fit_transform requires y'
 
         X = pd.Series(X.squeeze()).fillna(MISSING_VALUE_INDICATOR).values
-
         Xv  = self._vect.fit_transform(X)
         self._model = self._model.fit(Xv, y)
+
         if self.mode == 'classification':
-            out = cross_val_predict(self._model, Xv, y, method='decision_function', n_jobs=3, cv=3)
+            # Aim for NUM_FOLDS, but ensure that we don't have more folds than the min label count of a particular class.
+            num_folds = min(self.NUM_FOLDS, y.value_counts().min())
+            if num_folds < 2:
+                raise ValueError("label class with count of 1 encountered - cannot perform stratified cross validation")
+            out = cross_val_predict(self._model, Xv, y, method='decision_function', n_jobs=self.NUM_JOBS, cv=num_folds)
         else:
-            out = cross_val_predict(self._model, Xv, y, n_jobs=3, cv=3)
+            out = cross_val_predict(self._model, Xv, y, n_jobs=self.NUM_JOBS, cv=self.NUM_FOLDS)
 
         if len(out.shape) == 1:
             out = out.reshape(-1, 1)

--- a/distil/primitives/text_encoder.py
+++ b/distil/primitives/text_encoder.py
@@ -84,6 +84,8 @@ class TextEncoderPrimitive(base.PrimitiveBase[Inputs, Outputs, Params, Hyperpara
                  hyperparams: Hyperparams,
                  random_seed: int = 0) -> None:
         super().__init__(hyperparams=hyperparams, random_seed=random_seed)
+        self._encoders: List[SVMTextEncoder] = []
+        self._cols: List[int] = []
 
     def __getstate__(self) -> dict:
         state = base.PrimitiveBase.__getstate__(self)
@@ -114,7 +116,6 @@ class TextEncoderPrimitive(base.PrimitiveBase[Inputs, Outputs, Params, Hyperpara
 
         self._cols = list(cols)
         self._encoders: List[SVMTextEncoder] = []
-        self._encoder: None
         if len(cols) is 0:
             return base.CallResult(None)
 

--- a/distil/primitives/text_encoder.py
+++ b/distil/primitives/text_encoder.py
@@ -100,10 +100,11 @@ class TextEncoderPrimitive(base.PrimitiveBase[Inputs, Outputs, Params, Hyperpara
 
     def set_training_data(self, *, inputs: Inputs, outputs: Outputs) -> None:
         self._inputs = inputs
+
         # https://github.com/scikit-learn/scikit-learn/issues/14429#issuecomment-513887163
         if type(outputs) == container.pandas.DataFrame and outputs.shape[1] == 1:
             outputs = outputs.values.reshape(outputs.shape[0], )
-        self._outputs = outputs
+        self._outputs = pd.Series(outputs)
 
     def fit(self, *, timeout: float = None, iterations: int = None) -> base.CallResult[None]:
         logger.debug(f'Fitting {__name__}')

--- a/test/test_text_encoder.py
+++ b/test/test_text_encoder.py
@@ -1,0 +1,85 @@
+"""
+   Copyright © 2019 Uncharted Software Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+import unittest
+from os import path
+import sys
+
+from d3m import container
+
+from d3m.metadata import base as metadata_base
+from distil.primitives.text_encoder import TextEncoderPrimitive
+from distil.primitives import utils
+import utils as test_utils
+
+class TextEncoderPrimitiveTestCase(unittest.TestCase):
+
+    _dataset_path = path.abspath(path.join(path.dirname(__file__), 'text_encoder_dataset'))
+
+    def test_defaults(self) -> None:
+        # load test data into a dataframe
+        dataset = test_utils.load_dataset(self._dataset_path)
+        dataframe = test_utils.get_dataframe(dataset, 'learningData')
+
+        # create the encoder
+        hyperparams_class = \
+            TextEncoderPrimitive.metadata.query()['primitive_code']['class_type_arguments']['Hyperparams']
+        encoder = TextEncoderPrimitive(hyperparams=hyperparams_class.defaults())
+        encoder.set_training_data(inputs=dataframe.iloc[:, [0, 1]], outputs=dataframe.iloc[:, 2])
+        encoder.fit()
+        result = encoder.produce(inputs=dataframe).value
+
+        # don't assert on invidual values - just check basic sanity of result
+        self.assertEqual(len(result.index), 9)
+        self.assertSequenceEqual(list(result.columns), ["d3mIndex", "bravo", "__text_0", "__text_1", "__text_2"])
+        self.assertSequenceEqual(result.dtypes.tolist(), [object, object, float, float, float])
+
+    def test_classification_binary_label(self) -> None:
+        # load test data into a dataframe
+        dataset = test_utils.load_dataset(self._dataset_path)
+        dataframe = test_utils.get_dataframe(dataset, 'learningData')
+        dataframe = dataframe.iloc[0:5]
+
+        # create the encoder
+        hyperparams_class = \
+            TextEncoderPrimitive.metadata.query()['primitive_code']['class_type_arguments']['Hyperparams']
+        encoder = TextEncoderPrimitive(hyperparams=hyperparams_class.defaults())
+        encoder.set_training_data(inputs=dataframe.iloc[:, [0, 1]], outputs=dataframe.iloc[:, 2])
+        encoder.fit()
+        result = encoder.produce(inputs=dataframe).value
+
+        # don't assert on invidual values - just check basic sanity of result
+        self.assertEqual(len(result.index), 5)
+        self.assertSequenceEqual(list(result.columns), ["d3mIndex", "bravo", "__text_0"])
+        self.assertSequenceEqual(result.dtypes.tolist(), [object, object, float])
+
+    def test_classification_singleton_label(self) -> None:
+        # load test data into a dataframe
+        dataset = test_utils.load_dataset(self._dataset_path)
+        dataframe = test_utils.get_dataframe(dataset, 'learningData')
+        dataframe = dataframe.iloc[0:6]
+
+        # create the encoder
+        hyperparams_class = \
+            TextEncoderPrimitive.metadata.query()['primitive_code']['class_type_arguments']['Hyperparams']
+        encoder = TextEncoderPrimitive(hyperparams=hyperparams_class.defaults())
+        encoder.set_training_data(inputs=dataframe.iloc[:, [0, 1]], outputs=dataframe.iloc[:, 2])
+
+        # should fail in this case because we have a label with a cardinality of 1
+        self.assertRaises(ValueError, encoder.fit)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/text_encoder_dataset/datasetDoc.json
+++ b/test/text_encoder_dataset/datasetDoc.json
@@ -1,0 +1,40 @@
+{
+  "about": {
+    "datasetID": "test_data",
+    "datasetName": "test_data",
+    "license": "CC-BY license",
+    "approximateSize": "",
+    "datasetSchemaVersion": "3.1.1",
+    "redacted": true,
+    "datasetVersion": "1.0"
+  },
+  "dataResources": [
+    {
+      "resID": "learningData",
+      "resPath": "tables/learningData.csv",
+      "resType": "table",
+      "resFormat": ["text/csv"],
+      "isCollection": false,
+      "columns": [
+        {
+          "colIndex": 0,
+          "colName": "d3mIndex",
+          "colType": "integer",
+          "role": ["index"]
+        },
+        {
+          "colIndex": 1,
+          "colName": "alpha",
+          "colType": "string",
+          "role": ["attribute"]
+        },
+        {
+          "colIndex": 2,
+          "colName": "bravo",
+          "colType": "categorical",
+          "role": ["attribute"]
+        }
+      ]
+    }
+  ]
+}

--- a/test/text_encoder_dataset/tables/learningData.csv
+++ b/test/text_encoder_dataset/tables/learningData.csv
@@ -1,0 +1,10 @@
+d3mIndex,alpha,bravo
+1,"It is a period of civil wars in the galaxy. A brave alliance of underground freedom fighters has challenged the tyranny and oppression of the awesome GALACTIC EMPIRE.",0
+2,"Striking from a fortress hidden among the billion stars of the galaxy, rebel spaceships have won their first victory in a battle with the powerful Imperial Starfleet.",1
+3,"Striking from a fortress hidden among the billion stars of the galaxy, rebel spaceships have won their first victory in a battle with the powerful Imperial Starfleet.",1
+4,"It is a period of civil wars in the galaxy. A brave alliance of underground freedom fighters has challenged the tyranny and oppression of the awesome GALACTIC EMPIRE.",0
+5,"Striking from a fortress hidden among the billion stars of the galaxy, rebel spaceships have won their first victory in a battle with the powerful Imperial Starfleet.",1
+6,"The EMPIRE fears that another defeat could bring a thousand more solar systems into the rebellion, and Imperial control over the galaxy would be lost forever.",2
+7,"The EMPIRE fears that another defeat could bring a thousand more solar systems into the rebellion, and Imperial control over the galaxy would be lost forever.",2
+8,"It is a period of civil wars in the galaxy. A brave alliance of underground freedom fighters has challenged the tyranny and oppression of the awesome GALACTIC EMPIRE.",0
+9,"The EMPIRE fears that another defeat could bring a thousand more solar systems into the rebellion, and Imperial control over the galaxy would be lost forever.",2


### PR DESCRIPTION
fixes #114 Will safely handle cases where there are at least 2 labels per class.  The stratified kfold functionality of the underlying sklearn library does not appear to support singleton labels, so we check for this condition and raise an error.  A primitive like the distil singleton replacer can be inserted into a pipeline prior to the text encoder to ensure singleton labels are appropriately handled.