### PR TITLE
Post merge cleanup

### DIFF
--- a/distil/modeling/community_detection.py
+++ b/distil/modeling/community_detection.py
@@ -5,18 +5,17 @@ from .base import DistilBaseModel
 from .metrics import metrics
 
 class CommunityDetection(DistilBaseModel):
-    
-    def __init__(self, target_metric, overlapping):
-        self.target_metric = target_metric
+
+    def __init__(self, overlapping):
         self.overlapping   = overlapping
-    
+
     def fit(self, X_train, y_train, U_train=None):
         print('!! CommunityDetection: using null model', file=sys.stderr)
         return self
-    
+
     def predict(self, X):
         return -np.arange(X.shape[0])
-    
+
     @property
     def details(self):
         return {

--- a/distil/modeling/forest.py
+++ b/distil/modeling/forest.py
@@ -41,7 +41,6 @@ class AnyForest:
         #     assert y.dtype == int
         #     assert y.min() == 0, 'may need to remap_labels'
         #     assert y.max() == len(set(y)) - 1, 'may need to remap_labels'
-
         self.model = self.model_cls(**self.params).fit(X, y)
         return self
 
@@ -137,7 +136,6 @@ class ForestCV(DistilBaseModel):
             oob_score=True,
             n_jobs=self.inner_jobs,
             **params,
-            random_state=self.random_seed
         )
 
         model       = model.fit(X, y)
@@ -149,6 +147,7 @@ class ForestCV(DistilBaseModel):
         X, y = maybe_subset(Xf_train, y_train, n=self.subset)
 
         current_params = self.params
+        current_params['random_state'] = self.random_seed
 
         model = AnyForest(mode=self.mode, n_jobs=self.outer_jobs, **current_params)
 

--- a/distil/modeling/forest.py
+++ b/distil/modeling/forest.py
@@ -79,8 +79,8 @@ class ForestCV(DistilBaseModel):
     }
 
     def __init__(self, target_metric, subset=100000, final_subset=1500000,
-
-        verbose=10, num_fits=1, inner_jobs=1, param_grid=None, random_seed=None, hyperparams=None):
+        verbose=10, num_fits=1, inner_jobs=1, grid_search=False, param_grid=None, random_seed=None,
+        hyperparams=None):
 
         self.target_metric = target_metric
 
@@ -101,18 +101,21 @@ class ForestCV(DistilBaseModel):
         self.params = hyperparams
         self.random_seed = random_seed
 
-
-        if param_grid is not None:
-            self.param_grid = param_grid
+        # optional support for internal grid search
+        if grid_search:
+            if param_grid is not None:
+                self.param_grid = param_grid
+            else:
+                self.param_grid = deepcopy(self.default_param_grids[self.mode])
         else:
-            self.param_grid = deepcopy(self.default_param_grids[self.mode])
+            self.param_grid = None
 
         self._models  = []
         self._y_train = None
 
     def fit(self, Xf_train, y_train, U_train=None):
         self._y_train = y_train
-        self._models  = [self._fit(Xf_train, y_train) for _ in range(self.num_fits)]
+        self._models  = [self._fit(Xf_train, y_train, self.param_grid) for _ in range(self.num_fits)]
         return self
 
     # def score(self, X, y):
@@ -131,7 +134,8 @@ class ForestCV(DistilBaseModel):
     def feature_importances(self):
         return self._models[0].feature_importances()
 
-    def _eval_grid_point(self, params, X, y):
+    def _eval_grid_point(self, params, X, y, random_seed=None):
+        params['random_state'] = random_seed
         model = AnyForest(
             mode=self.mode,
             oob_score=True,
@@ -147,12 +151,24 @@ class ForestCV(DistilBaseModel):
 
         X, y = maybe_subset(Xf_train, y_train, n=self.subset)
 
-        current_params = self.params
-        current_params['random_state'] = self.random_seed
+        # Run grid search
+        if param_grid is not None:
+            self.results = parmap(self._eval_grid_point,
+                ParameterGrid(self.param_grid), X=X, y=y, verbose=self.verbose, n_jobs=self.outer_jobs, random_seed=self.random_seed)
 
-        model = AnyForest(mode=self.mode, n_jobs=self.outer_jobs, **current_params)
+            # Find best run
+            best_run = sorted(self.results, key=lambda x: x['fitness'])[-1] # bigger is better
+            self.best_params, self.best_fitness = best_run['params'], best_run['fitness']
 
-        model = model.fit(X, y)
+            # Refit best model, possibly on more data
+            X, y  = maybe_subset(Xf_train, y_train, n=self.final_subset)
+            model = AnyForest(mode=self.mode, n_jobs=self.outer_jobs, **self.best_params)
+            model = model.fit(X, y)
+        else:
+            current_params = self.params
+            current_params['random_state'] = self.random_seed
+            model = AnyForest(mode=self.mode, n_jobs=self.outer_jobs, **current_params)
+            model = model.fit(X, y)
 
         return model
 

--- a/distil/modeling/forest.py
+++ b/distil/modeling/forest.py
@@ -41,6 +41,7 @@ class AnyForest:
         #     assert y.dtype == int
         #     assert y.min() == 0, 'may need to remap_labels'
         #     assert y.max() == len(set(y)) - 1, 'may need to remap_labels'
+        y = y.ravel(order='C')
         self.model = self.model_cls(**self.params).fit(X, y)
         return self
 

--- a/distil/modeling/text_classification.py
+++ b/distil/modeling/text_classification.py
@@ -40,7 +40,7 @@ class TextClassifierCV(DistilBaseModel):
         self.model = RandomizedSearchCV(
             Pipeline([
                 ('vect', TfidfVectorizer()),
-                ('cls', LinearSVC())
+                ('cls', LinearSVC(random_state=self.random_seed))
             ]),
             n_iter=self.n_iter,
             param_distributions=self.param_grid,

--- a/distil/modeling/vertex_nomination.py
+++ b/distil/modeling/vertex_nomination.py
@@ -15,7 +15,7 @@ class VertexNominationCV(DistilBaseModel):
     def __init__(self, target_metric, num_components=8,random_seed=None):
         self.target_metric  = target_metric
         self.num_components = num_components
-        self._random_seed = random_seed
+        self.random__seed = random_seed
         self.feats = None
 
     def fit(self, X_train, y_train, U_train=None):
@@ -42,7 +42,7 @@ class VertexNominationCV(DistilBaseModel):
         print('VertexNominationCV: ForestCV', file=sys.stderr)
         forest = False
         try:
-            forest = ForestCV(target_metric=self.target_metric,random_seed=self._random_seed)
+            forest = ForestCV(target_metric=self.target_metric,random_seed=self.random__seed,grid_search=True)
             forest = forest.fit(Xf_train, y_train)
         except:
             pass
@@ -50,8 +50,8 @@ class VertexNominationCV(DistilBaseModel):
         print('VertexNominationCV: SupportVectorCV', file=sys.stderr)
         svm = False
         try:
-            svm = SupportVectorCV(target_metric=self.target_metric)
-            #svm = svm.fit(Xf_train, y_train)
+            svm = SupportVectorCV(target_metric=self.target_metric, random_seed=self.random__seed)
+            svm = svm.fit(Xf_train, y_train)
         except:
             pass
 

--- a/distil/primitives/audio_transfer.py
+++ b/distil/primitives/audio_transfer.py
@@ -1,11 +1,11 @@
 import logging
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 import pandas as pd
 from d3m import container, utils
 from d3m.metadata import base as metadata_base, hyperparams, params
-from d3m.primitive_interfaces import base, unsupervised_learning
+from d3m.primitive_interfaces import base, transformer
 from d3m.primitive_interfaces.base import CallResult
 from d3m.primitive_interfaces.supervised_learning import PrimitiveBase
 from distil.primitives import utils as primitive_utils
@@ -15,8 +15,11 @@ __all__ = ('AudioTransferPrimitive',)
 
 logger = logging.getLogger(__name__)
 
+Inputs = container.List
+Outputs = container.DataFrame
+
 # lazy load pretrained audio due to lengthy import time
-pretrained_audio = primitive_utils.lazy_load("distil.modeling.pretrained_audio")
+_pretrained_audio = primitive_utils.lazy_load("distil.modeling.pretrained_audio")
 
 class Hyperparams(hyperparams.Hyperparams):
     use_columns = hyperparams.Set(
@@ -29,20 +32,14 @@ class Hyperparams(hyperparams.Hyperparams):
         default='',
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
     )
-    fast = hyperparams.Hyperparameter[bool](
-        default=False,
-        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
-    )
 
-class Params(params.Params):
-    pass
-
-
-class AudioTransferPrimitive(unsupervised_learning.UnsupervisedLearnerPrimitiveBase[container.List, container.DataFrame, Params, Hyperparams]):
+class AudioTransferPrimitive(transformer.TransformerPrimitiveBase[Inputs, Outputs, Hyperparams]):
     """
     A primitive that converts an input audio waveform to a vector of VGGish features.
 
     """
+
+    _VOLUME_KEY = 'vggish_model'
 
     metadata = metadata_base.PrimitiveMetadata(
         {
@@ -60,7 +57,7 @@ class AudioTransferPrimitive(unsupervised_learning.UnsupervisedLearnerPrimitiveB
             },
             'installation': [{
                     "type": "FILE",
-                    "key": "vggish_model",
+                    "key": _VOLUME_KEY,
                     "file_uri": "https://github.com/harritaylor/torchvggish/releases/download/v0.1/vggish-10086976.pth",
                     "file_digest": "10086976245803799d9194e9a73d9b6c1549c71d1b80106f5cade5608a561f4b",
                 }, {
@@ -94,53 +91,33 @@ class AudioTransferPrimitive(unsupervised_learning.UnsupervisedLearnerPrimitiveB
         },
     )
 
+    _audio_set: Optional[_pretrained_audio.AudiosetModel] = None
 
     def __init__(self, *,
                  hyperparams: Hyperparams,
                  random_seed: int=0,
                  volumes: Dict[str, str] = None) -> None:
-
         super().__init__(hyperparams=hyperparams, random_seed=random_seed, volumes=volumes)
-        self.volumes = volumes
-        self.audio_set = pretrained_audio.AudiosetModel(model_path=self.volumes["vggish_model"])
-
-    def __getstate__(self) -> dict:
-        state = PrimitiveBase.__getstate__(self)
-
-        return state
-
-    def __setstate__(self, state: dict) -> None:
-        PrimitiveBase.__setstate__(self, state)
-
-
-    def set_training_data(self, *, inputs: container.List) -> None:
-        self._inputs = inputs
-
+        if volumes is None:
+            raise ValueError('volumes cannot be None')
 
     def _transform_inputs(self, inputs):
-        feats = self.audio_set._featurize(inputs.audio)
+        feats = self._audio_set._featurize(inputs.audio)
         audio_vecs = pd.DataFrame(feats.tolist())
         audio_vecs.columns = ['v{}'.format(i) for i in range(0, audio_vecs.shape[1])]
 
         return container.DataFrame(audio_vecs) # TODO: fix index setup
 
-
-    def fit(self, *, timeout: float = None, iterations: int = None) -> CallResult[None]:
-        return CallResult(None)
-
-
-    def produce(self, *, inputs: container.List, timeout: float = None, iterations: int = None) -> CallResult[container.DataFrame]:
+    def produce(self, *, inputs: Inputs, timeout: float = None, iterations: int = None) -> CallResult[container.DataFrame]:
         logger.debug(f'Producing {__name__}')
+
+         # lazy init the audio set model
+        if self._audio_set is None:
+            model_path = self.volumes[self._VOLUME_KEY]
+            logger.debug(f'Loading pretrained model from {model_path}')
+            self._audio_set = _pretrained_audio.AudiosetModel(model_path=model_path)
+
         outputs = self._transform_inputs(inputs)
         logger.debug(f'Audio transfer completed on {len(outputs.columns)} samples')
 
         return base.CallResult(outputs)
-
-
-    def get_params(self) -> Params:
-        return Params()
-
-
-    def set_params(self, *, params: Params) -> None:
-        return
-

--- a/distil/primitives/audio_transfer.py
+++ b/distil/primitives/audio_transfer.py
@@ -28,10 +28,6 @@ class Hyperparams(hyperparams.Hyperparams):
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter'],
         description="A set of column indices to force primitive to operate on. If any specified column cannot be parsed, it is skipped.",
     )
-    metric = hyperparams.Hyperparameter[str](
-        default='',
-        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
-    )
 
 class AudioTransferPrimitive(transformer.TransformerPrimitiveBase[Inputs, Outputs, Hyperparams]):
     """

--- a/distil/primitives/community_detection.py
+++ b/distil/primitives/community_detection.py
@@ -15,10 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class Hyperparams(hyperparams.Hyperparams):
-    metric = hyperparams.Hyperparameter[str](
-        default='normalizedMutualInformation',
-        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
-    )
+    pass
 
 class Params(params.Params):
     model: _CommunityDetection
@@ -61,7 +58,7 @@ class DistilCommunityDetectionPrimitive(PrimitiveBase[container.List, container.
                  random_seed: int = 0) -> None:
 
         super().__init__(hyperparams=hyperparams, random_seed=random_seed)
-        self._model = _CommunityDetection(target_metric=self.hyperparams['metric'], overlapping=False)
+        self._model = _CommunityDetection(overlapping=False)
         self._target_col = ""
 
     def set_training_data(self, *, inputs: container.List, outputs: container.DataFrame) -> None:

--- a/distil/primitives/ensemble_forest.py
+++ b/distil/primitives/ensemble_forest.py
@@ -37,7 +37,7 @@ class Hyperparams(hyperparams.Hyperparams):
         + "fewer rows than the threshold value, 'small_dateset_fits' will be used when fitting.  Otherwise, 'num_large_fits' is used.",
     )
     small_dataset_fits = hyperparams.Hyperparameter[int](
-        default=1,
+        default=5,
         semantic_types=[
             "https://metadata.datadrivendiscovery.org/types/ControlParameter"
         ],
@@ -170,21 +170,10 @@ class EnsembleForestPrimitive(
             current_hyperparams.update({"bootstrap": True})
 
 
-        self._model = ForestCV(self.hyperparams["metric"], self.random_seed, hyperparams=current_hyperparams)
+        self._model = ForestCV(self.hyperparams["metric"], random_seed=self.random_seed, hyperparams=current_hyperparams)
         self._needs_fit = True
-        self.label_map: Optional[Dict[int, str]] = None
+        self._label_map: Dict[int, str] = {}
         self._target_cols: List[str] = []
-
-    def __getstate__(self) -> dict:
-        state = PrimitiveBase.__getstate__(self)
-        state["models"] = self._model
-        state["needs_fit"] = self._needs_fit
-        return state
-
-    def __setstate__(self, state: dict) -> None:
-        PrimitiveBase.__setstate__(self, state)
-        self._model = state["models"]
-        self._needs_fit = True
 
     def _get_component_columns(
         self, output_df: container.DataFrame, source_col_index: int

--- a/distil/primitives/ensemble_forest.py
+++ b/distil/primitives/ensemble_forest.py
@@ -11,7 +11,7 @@ from d3m.primitive_interfaces import base
 from d3m.primitive_interfaces.base import CallResult
 from d3m.primitive_interfaces.supervised_learning import PrimitiveBase
 from distil.modeling.forest import ForestCV
-from distil.modeling.metrics import classification_metrics
+from distil.modeling.metrics import classification_metrics, regression_metrics
 from distil.utils import CYTHON_DEP
 
 __all__ = ("EnsembleForest",)
@@ -20,7 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 class Hyperparams(hyperparams.Hyperparams):
-    metric = hyperparams.Hyperparameter[str](
+    metric = hyperparams.Enumeration[str](
+        values=classification_metrics.union(regression_metrics),
         default="f1Macro",
         semantic_types=[
             "https://metadata.datadrivendiscovery.org/types/ControlParameter"

--- a/distil/primitives/image_transfer.py
+++ b/distil/primitives/image_transfer.py
@@ -6,8 +6,7 @@ import pandas as pd
 from PIL import Image
 from d3m import container, utils
 from d3m.metadata import base as metadata_base, hyperparams, params
-from d3m.primitive_interfaces import base
-from d3m.primitive_interfaces import unsupervised_learning
+from d3m.primitive_interfaces import base, transformer
 from d3m.primitive_interfaces.base import CallResult
 from distil.utils import CYTHON_DEP
 from distil.utils import Img2Vec
@@ -16,18 +15,19 @@ __all__ = ('ImageTransferPrimitive',)
 
 logger = logging.getLogger(__name__)
 
-VOLUME_KEY = 'resnet18-5c106cde'
+Inputs = container.DataFrame
+Outputs = container.DataFrame
+
 
 class Hyperparams(hyperparams.Hyperparams):
     pass
 
-class Params(params.Params):
-    model: Img2Vec
-
-class ImageTransferPrimitive(unsupervised_learning.UnsupervisedLearnerPrimitiveBase[container.DataFrame, container.DataFrame, Params, Hyperparams]):
+class ImageTransferPrimitive(transformer.TransformerPrimitiveBase[Inputs, Outputs, Hyperparams]):
     """
     A primitive that converts an input image to a vector of 512 numerical features.
     """
+
+    _VOLUME_KEY = 'resnet18-5c106cde'
 
     metadata = metadata_base.PrimitiveMetadata(
         {
@@ -52,7 +52,7 @@ class ImageTransferPrimitive(unsupervised_learning.UnsupervisedLearnerPrimitiveB
                 },
                 {
                     "type": "FILE",
-                    "key": VOLUME_KEY,
+                    "key": _VOLUME_KEY,
                     "file_uri": "http://public.datadrivendiscovery.org/resnet18-5c106cde.pth",
                     "file_digest": "5c106cde386e87d4033832f2996f5493238eda96ccf559d1d62760c4de0613f8",
                 }
@@ -65,6 +65,8 @@ class ImageTransferPrimitive(unsupervised_learning.UnsupervisedLearnerPrimitiveB
         },
     )
 
+    # class instance to avoid unnecessary re-init
+    _model: Optional[Img2Vec] = None
 
     def __init__(self, *,
                  hyperparams: Hyperparams,
@@ -74,12 +76,10 @@ class ImageTransferPrimitive(unsupervised_learning.UnsupervisedLearnerPrimitiveB
         super().__init__(hyperparams=hyperparams, random_seed=random_seed, volumes=volumes)
         if volumes is None:
             raise ValueError('volumes cannot be None')
-        self._volumes: Dict[str, str] = volumes
-        self._img2vec: Optional[Img2Vec] = None
 
     def _img_to_vec(self, image_array):
         image_array = image_array.squeeze()
-        return self._img2vec.get_vec(Image.fromarray(image_array).convert('RGB'))
+        return self._model.get_vec(Image.fromarray(image_array).convert('RGB'))
 
     def _transform_inputs(self, inputs):
         result = inputs.copy()
@@ -93,28 +93,13 @@ class ImageTransferPrimitive(unsupervised_learning.UnsupervisedLearnerPrimitiveB
 
         return container.DataFrame(df, generate_metadata=True)
 
-    def set_training_data(self, *, inputs: container.DataFrame) -> None:
-        pass
-
-    def fit(self, *, timeout: float = None, iterations: int = None) -> base.CallResult[None]:
-        model_path = self._volumes[VOLUME_KEY]
-        if model_path is None:
-            raise ValueError(f'no volume information found for {VOLUME_KEY}')
-
-        if self._img2vec is None:
-            logger.info(f'Loading pre-trained model from {model_path}')
-            self._img2vec = Img2Vec(model_path)
-            logger.info(f'Finished loading pre-trained model')
-        return base.CallResult(None)
-
     def produce(self, *, inputs: container.DataFrame, timeout: float = None, iterations: int = None) -> CallResult[container.DataFrame]:
         logger.debug(f'Producing {__name__}')
+
+        if self._model is None:
+            model_path = self.volumes[self._VOLUME_KEY]
+            logger.info(f'Loading pre-trained model from {model_path}')
+            self._model = Img2Vec(model_path)
+
         return base.CallResult(self._transform_inputs(inputs))
 
-    def get_params(self) -> Params:
-        return Params(
-            model=self._img2vec
-        )
-
-    def set_params(self, *, params: Params) -> None:
-        self._img2vec=params['model']

--- a/distil/primitives/link_prediction.py
+++ b/distil/primitives/link_prediction.py
@@ -7,6 +7,7 @@ from d3m.primitive_interfaces import base
 from d3m.primitive_interfaces.base import CallResult
 from d3m.primitive_interfaces.supervised_learning import PrimitiveBase
 from distil.modeling.link_prediction import RescalLinkPrediction
+from distil.modeling.metrics import classification_metrics
 from distil.utils import CYTHON_DEP
 
 __all__ = ('LinkPrediction',)
@@ -15,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class Hyperparams(hyperparams.Hyperparams):
-    metric = hyperparams.Hyperparameter[str](
+    metric = hyperparams.Enumeration[str](
+        values=classification_metrics,
         default='accuracy',
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
     )

--- a/distil/primitives/seeded_graph_matching.py
+++ b/distil/primitives/seeded_graph_matching.py
@@ -7,6 +7,7 @@ from d3m.primitive_interfaces import base
 from d3m.primitive_interfaces.base import CallResult
 from d3m.primitive_interfaces.supervised_learning import PrimitiveBase
 from distil.modeling.sgm import SGMGraphMatcher
+from distil.modeling.metrics import classification_metrics
 from distil.utils import CYTHON_DEP
 
 __all__ = ('SeededGraphMatcher',)
@@ -15,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class Hyperparams(hyperparams.Hyperparams):
-    metric = hyperparams.Hyperparameter[str](
+    metric = hyperparams.Enumeration[str](
+        values=classification_metrics,
         default='accuracy',
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
     )

--- a/distil/primitives/text_classifier.py
+++ b/distil/primitives/text_classifier.py
@@ -7,7 +7,7 @@ from d3m import container, utils
 from d3m.metadata import base as metadata_base, hyperparams, params
 from d3m.primitive_interfaces import base
 from d3m.primitive_interfaces.base import CallResult
-from distil.modeling.metrics import classification_metrics, regression_metrics
+from distil.modeling.metrics import classification_metrics
 from distil.modeling.text_classification import TextClassifierCV
 from distil.utils import CYTHON_DEP
 
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 class Hyperparams(hyperparams.Hyperparams):
-    metric = hyperparams.Hyperparameter[str](
+    metric = hyperparams.Enumeration[str](
+        values=classification_metrics,
         default='f1',
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
     )

--- a/distil/primitives/text_classifier.py
+++ b/distil/primitives/text_classifier.py
@@ -21,11 +21,6 @@ class Hyperparams(hyperparams.Hyperparams):
         default='f1',
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
     )
-    fast = hyperparams.Hyperparameter[bool](
-        default=False,
-        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
-    )
-
 
 class Params(params.Params):
     model: TextClassifierCV
@@ -126,14 +121,6 @@ class TextClassifierPrimitive(base.PrimitiveBase[container.DataFrame, container.
                                                                   'https://metadata.datadrivendiscovery.org/types/PredictedTarget')
 
         return base.CallResult(result_df)
-
-    def _get_grid_for_metric(self) -> Dict[str, Any]:
-        if self.hyperparams['metric'] in classification_metrics:
-            return self._FAST_GRIDS['classification']
-        elif self.hyperparams['metric'] in regression_metrics:
-            raise NotImplementedError
-        else:
-            raise Exception('ForestCV: unknown metric')
 
     def get_params(self) -> Params:
         return Params(

--- a/distil/primitives/text_encoder.py
+++ b/distil/primitives/text_encoder.py
@@ -8,6 +8,7 @@ from d3m.metadata import base as metadata_base, hyperparams, params
 from d3m.primitive_interfaces import base
 from distil.preprocessing.transformers import SVMTextEncoder, TfidifEncoder
 from distil.primitives import utils as distil_utils
+from distil.modeling.metrics import classification_metrics, clustering_metrics, regression_metrics
 from distil.utils import CYTHON_DEP
 
 __all__ = ('TextEncoderPrimitive',)
@@ -19,7 +20,8 @@ Outputs = container.DataFrame
 
 
 class Hyperparams(hyperparams.Hyperparams):
-    metric = hyperparams.Hyperparameter[str](
+    metric = hyperparams.Enumeration[str](
+        values=clustering_metrics.union(classification_metrics).union(regression_metrics),
         default="f1Macro",
         semantic_types=[
             "https://metadata.datadrivendiscovery.org/types/ControlParameter"

--- a/distil/primitives/vertex_nomination.py
+++ b/distil/primitives/vertex_nomination.py
@@ -8,6 +8,7 @@ from d3m.primitive_interfaces.base import CallResult
 from d3m.primitive_interfaces.supervised_learning import PrimitiveBase
 from distil.modeling.vertex_nomination import VertexNominationCV
 from distil.utils import CYTHON_DEP
+from distil.modeling.metrics import classification_metrics
 
 __all__ = ('VertexNomination',)
 
@@ -15,8 +16,9 @@ logger = logging.getLogger(__name__)
 
 
 class Hyperparams(hyperparams.Hyperparams):
-    metric = hyperparams.Hyperparameter[str](
-        default='normalizedMutualInformation',
+    metric = hyperparams.Enumeration[str](
+        values=classification_metrics,
+        default='accuracy',
         semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter']
     )
 


### PR DESCRIPTION
1. Uses enumertions for metric hyperparameters to better support TA2 querying.
1. Fixes failures in vertex nomination by re-introducing grid search to ensemble forest, and adding a property to optionally enable it.  Default is disabled.
1. Re-enables SVM for vertex nomination.  Not sure why it was disabled - if it fails to run the RF results will be used, and it currently yields a better final score.