### PR TITLE
fix input check in shap values produce()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'rescal @ git+https://github.com/cdbethune/rescal.py.git@af2091c1d5521c987edd3be41627b9c563582fe8',
         'pytorch-pretrained-bert @ git+https://github.com/cdbethune/pytorch-pretrained-BERT.git@fb5a42d9de9385b146ba585d6d47ec36d27dcbca#egg=pytorch-pretrained-bert',
 	    'scikit-image<=0.16.1', # need this to ensure compatiblity with pillow 7.1.1
-        'ShapExplainers @ git+https://github.com/cdbethune/shap_explainers.git@1010e2fcd6206c23e6bb7e78905f2e345277afc0#egg=ShapExplainers',
+        'shap>=0.35.0',
         # Can cause errors with pretrained-bert: https://github.com/NVIDIA/apex/issues/156
         #'apex @ git+https://github.com/NVIDIA/apex.git@47e3367fcd6636db6cd549bbb385a6e06a3861d0',
         'torchvggish @ git+https://github.com/harritaylor/torchvggish.git@f5ec66cb05029ddfdb9971f343d79408fac44c70#egg=torchvggish',


### PR DESCRIPTION
Closes #129 

-check train set equality with hash instead of df, serialize input frame hash
-import directly from `shap` python library instead of `ShapExplainers` or `kf-d3m-primitives`

-note: there is an open known issue (https://github.com/slundberg/shap/issues/1071) that the additivity check occasionally fails (my guess is numerical precision when we convert categoricals to hashes...). This only happens ~10% of the time in my testing on ACLED. A `try-except` loop doesn't help, because it seems to derive from a problem with the fit model. The good news is that simply re-running the pipeline seems to fix the issue (and I assume the `shap` library will address at some point in the future). 