### PR TITLE
adds recognition of python float, integer types

### DIFF
--- a/distil/primitives/k_means.py
+++ b/distil/primitives/k_means.py
@@ -81,8 +81,11 @@ class KMeansPrimitive(unsupervised_learning.UnsupervisedLearnerPrimitiveBase[con
     def fit(self, *, timeout: float = None, iterations: int = None) -> base.CallResult[None]:
         logger.debug(f'Fitting {__name__}')
 
+        self._inputs.metadata.pretty_print()
+
         # find candidate columns
-        self._cols = distil_utils.get_operating_columns_structural_type(self._inputs, self.hyperparams['use_columns'], (np.float32, np.float64, np.int64), False)
+        self._cols = distil_utils.get_operating_columns_structural_type(self._inputs, self.hyperparams['use_columns'],
+            (np.float32, np.float64, np.int64, type(float).__name__, type(int).__name__), False)
         logger.debug(f'Found {len(self._cols)} cols to use for clustering')
         return base.CallResult(None)
 


### PR DESCRIPTION
The primitive was only recognizing numpy number types as valid data for processing.  Python base types are now recognized as well.  