### PR TITLE
Use structural type from the to_numeric results

### DIFF
--- a/test/test_column_parser.py
+++ b/test/test_column_parser.py
@@ -74,7 +74,7 @@ class ColumnParserPrimitiveTestCase(unittest.TestCase):
         df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 2), 'http://schema.org/Float')
         df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 3), 'http://schema.org/Integer')
         df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 4), 'http://schema.org/Boolean')
-        df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 5), 'http://schema.org/Float')
+        df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 5), 'http://schema.org/Integer')
         hyperparams_class = ColumnParserPrimitive.metadata.get_hyperparams()
         cpp = ColumnParserPrimitive(hyperparams=hyperparams_class.defaults() \
             .replace({'parsing_semantics': ['http://schema.org/Float', 'http://schema.org/Integer']}))


### PR DESCRIPTION
Set the structural type to the result of the pd numeric call, rather than the semantic type.  Required because the pandas `to_numeric` call my not be able to satisfy the semantic type.  One notable example is that a NaN in a column of integer values will result in the column being set to floats.