### PR TITLE
Satellite loader optimization

### DIFF
--- a/distil/primitives/satellite_image_loader.py
+++ b/distil/primitives/satellite_image_loader.py
@@ -186,7 +186,7 @@ class DataFrameSatelliteImageLoaderPrimitive(transformer.TransformerPrimitiveBas
         groups = inputs_clone.groupby([grouping_name], sort=False)
 
         # use the max dimension for the first group as the max dimension for all groups
-        group_key = list(groups.groups.keys())[0] # there must be a better way to do this
+        group_key = groups[grouping_name].first()[0]
         max_dimension = self._get_group_image_size(groups.get_group(group_key), file_column_name, band_column_name, base_uri)
 
         # load images for each group and store them in a matrix of [band, x, y]

--- a/test/test_satellite_image_loader.py
+++ b/test/test_satellite_image_loader.py
@@ -93,7 +93,7 @@ class DataFrameSatelliteImageLoaderPrimitiveTestCase(unittest.TestCase):
         result_array = np.frombuffer(decompressed_bytes[16:], dtype=storage_type).reshape(shape_0, shape_1, shape_2)
 
         # load a test image
-        original_image = image_array = imageio.imread("test/satellite_image_dataset/media/S2A_MSIL2A_20170613T101031_0_49_B02.tif")
+        original_image = image_array = imageio.imread("satellite_image_dataset/media/S2A_MSIL2A_20170613T101031_0_49_B02.tif")
         loaded_image = result_array[1]
         self.assertEqual(original_image.tobytes(), loaded_image.tobytes())
 


### PR DESCRIPTION
1. Parallelizes satellite image loading which was CPU bound due to processing done after load
1. Works around slow auto metadata generation on the produced dataframe by generating it on a single row of data, rather than the whole dataset.  End result is the same since the data should be homogenous.