### PR TITLE
Updates to geocoord filtering

### DIFF
--- a/distil/primitives/column_parser.py
+++ b/distil/primitives/column_parser.py
@@ -117,14 +117,12 @@ class ColumnParserPrimitive(
 
         parsing_semantics = self.hyperparams["parsing_semantics"]
 
-        def fromstring(x):
-            parsed_numbers = np.fromstring(x, dtype=float, sep=",")
-            return (
-                parsed_numbers
-                if len(parsed_numbers) > 0
-                # removes and brackets surrounding numbers in a last attempt
-                else np.fromstring(x[1 : len(x)], dtype=float, sep=",")
-            )
+        def fromstring(x: str) -> np.ndarray:
+            # if column isn't a string, we'll just pass it through assuming it doesn't need to be parsed
+            if type(x) is not str:
+                return x
+
+            return np.fromstring(x, dtype=float, sep=",")
 
         for col_index in range(len(inputs.columns)):
             if col_index in cols:

--- a/distil/primitives/vector_filter.py
+++ b/distil/primitives/vector_filter.py
@@ -44,8 +44,8 @@ class Hyperparams(hyperparams.Hyperparams):
         ]
     ](
         configuration=collections.OrderedDict(
-            sets=hyperparams.Set(
-                elements=hyperparams.Set(
+            sets=hyperparams.List(
+                elements=hyperparams.List(
                     elements=hyperparams.Hyperparameter[float](-1),
                     default=(),
                     semantic_types=[
@@ -59,7 +59,7 @@ class Hyperparams(hyperparams.Hyperparams):
                 ],
                 description="A set of minimum values, corresponding to the vector values to filter on",
             ),
-            set=hyperparams.Set(
+            set=hyperparams.List(
                 elements=hyperparams.Hyperparameter[float](-1),
                 default=(),
                 semantic_types=[
@@ -81,8 +81,8 @@ class Hyperparams(hyperparams.Hyperparams):
         ]
     ](
         configuration=collections.OrderedDict(
-            sets=hyperparams.Set(
-                elements=hyperparams.Set(
+            sets=hyperparams.List(
+                elements=hyperparams.List(
                     elements=hyperparams.Hyperparameter[float](-1),
                     default=(),
                     semantic_types=[
@@ -96,7 +96,7 @@ class Hyperparams(hyperparams.Hyperparams):
                 ],
                 description="A set of minimum values, corresponding to the vector values to filter on",
             ),
-            set=hyperparams.Set(
+            set=hyperparams.List(
                 elements=hyperparams.Hyperparameter[float](-1),
                 default=(),
                 semantic_types=[

--- a/test/test_column_parser.py
+++ b/test/test_column_parser.py
@@ -1,9 +1,5 @@
 import unittest
 from os import path
-import csv
-import sys
-import math
-import pandas as pd
 import numpy as np
 
 # from common_primitives.column_parser import ColumnParserPrimitive
@@ -166,6 +162,42 @@ class ColumnParserPrimitiveTestCase(unittest.TestCase):
             ],
             np.ndarray,
         )
+
+    def test_vector_parse_twice(self) -> None:
+        dataset = test_utils.load_dataset(self._image_dataset_path)
+        df = test_utils.get_dataframe(dataset, "learningData")
+
+        hyperparams_class = ColumnParserPrimitive.metadata.get_hyperparams()
+        cpp = ColumnParserPrimitive(
+            hyperparams=hyperparams_class.defaults().replace(
+                {
+                    "parsing_semantics": [
+                        "https://metadata.datadrivendiscovery.org/types/FloatVector",
+                    ]
+                }
+            )
+        )
+        target_coords = [
+            20.999598,
+            63.488694,
+            20.999598,
+            63.499462,
+            21.023702,
+            63.499462,
+            21.023702,
+            63.488694,
+        ]
+        result_df = cpp.produce(inputs=df).value
+        result_coords = result_df["coordinates"][0]
+        self.assertEquals(len(result_coords), len(target_coords))
+        for a, b in zip(target_coords, result_coords):
+            self.assertAlmostEqual(a, b, 5)
+
+        result_2_df = cpp.produce(inputs=result_df).value
+        result_2_coords = result_2_df["coordinates"][0]
+        self.assertEquals(len(result_2_coords), len(target_coords))
+        for a, b in zip(target_coords, result_2_coords):
+            self.assertAlmostEqual(a, b, 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Integration of the vector filter primitive into the data pre-processing pipeline revealed 2 issues:
1. The vector filter needed min/max hyperparameters to be `List` based, rather than `Set` based to support duplicate members.
1. The distil column parser needs to gracefully handle cases where the column parser has already been run, which happens when the TA3 adds a preprend.  This wasn't happening, which was resulting in the array data set to empty on the second pass.