### PR TITLE
Add license metadata to PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     description="Distil primitives as a single library",
     packages=find_packages(),
     keywords=["d3m_primitive"],
+    license='Apache-2.0',
     install_requires=[
         "d3m",  # d3m best-practice moving forward is to remove the version (simplifies updates)
         # shared d3m versions - need to be aligned with core package


### PR DESCRIPTION
The package shows as `UNKNOWN` right now and people have to come to the repository to find the LICENSE file.