### PR TITLE
removes metadata generation bottleneck

### DIFF
--- a/distil/primitives/fuzzy_join.py
+++ b/distil/primitives/fuzzy_join.py
@@ -352,7 +352,7 @@ class FuzzyJoinPrimitive(
         for k, v in resource_map.items():
             result_dataset[k] = v
             result_dataset.metadata = result_dataset.metadata.update(
-                (k,), {"dimension": {"length": 8}}
+                (k,), {"dimension": {"length": v.shape[0]}}
             )
 
         for key in float_vector_columns.keys():

--- a/distil/primitives/fuzzy_join.py
+++ b/distil/primitives/fuzzy_join.py
@@ -1,6 +1,7 @@
 import typing
 import os
 import collections
+from frozendict import FrozenOrderedDict
 
 import pandas as pd  # type: ignore
 import numpy as np
@@ -350,6 +351,9 @@ class FuzzyJoinPrimitive(
         )
         for k, v in resource_map.items():
             result_dataset[k] = v
+            result_dataset.metadata = result_dataset.metadata.update(
+                (k,), {"dimension": {"length": 8}}
+            )
 
         for key in float_vector_columns.keys():
             df = result_dataset["0"]

--- a/test/test_fuzzy_join.py
+++ b/test/test_fuzzy_join.py
@@ -1,9 +1,5 @@
 import unittest
 from os import path
-import csv
-import typing
-import math
-import pandas as pd
 import numpy as np
 
 from d3m import container


### PR DESCRIPTION
fixes #275  

Metadata generation on the full dataset was extremely slow - now runs on a single row version, since there isn't any use for per-cell metadata.  Once the metadata is generated, the full dataframe is moved into the dataset.