### PR TITLE
Fixed failing tests.

### DIFF
--- a/test/audio_dataset_1/datasetDoc.json
+++ b/test/audio_dataset_1/datasetDoc.json
@@ -45,18 +45,12 @@
         },
         {
           "colIndex": 2,
-          "colName": "start",
+          "colName": "start-end-time-slice-of-recording",
           "colType": "real",
           "role": ["boundaryIndicator"]
         },
         {
           "colIndex": 3,
-          "colName": "end",
-          "colType": "real",
-          "role": ["boundaryIndicator"]
-        },
-        {
-          "colIndex": 4,
           "colName": "class",
           "colType": "categorical",
           "role": ["suggestedTarget"]

--- a/test/audio_dataset_1/tables/learningData.csv
+++ b/test/audio_dataset_1/tables/learningData.csv
@@ -1,2 +1,2 @@
-d3mIndex,filename,start,end,class
-0,test_audio.mp3,0.007,0.008,test
+d3mIndex,filename,start-end-time-slice-of-recording,class
+0,test_audio.mp3,"0.007,0.008",test

--- a/test/test_audio_transfer.py
+++ b/test/test_audio_transfer.py
@@ -51,7 +51,7 @@ class AudioTransferPrimitiveTestCase(unittest.TestCase):
         dataframe_primitive = dataset_to_dataframe.DatasetToDataFramePrimitive(
             hyperparams=dataframe_hyperparams_class.defaults()
         )
-        df = dataframe_primitive.produce(inputs=dataset).value
+        audio_df = dataframe_primitive.produce(inputs=dataset).value
 
         audio_df.metadata = audio_df.metadata.add_semantic_type(
             (metadata_base.ALL_ELEMENTS, 0), "http://schema.org/AudioObject"
@@ -73,20 +73,14 @@ class AudioTransferPrimitiveTestCase(unittest.TestCase):
     def test_no_hyperparams_no_semantic_type(self):
         dataset = test_utils.load_dataset(self._dataset_path)
 
-        audio_loader_hyperparams = (
+        auto_loader_hyperparams_class = (
             AudioDatasetLoaderPrimitive.metadata.get_hyperparams()
         )
+        audio_loader_hyperparams = auto_loader_hyperparams_class.defaults()
         audio_loader_primitive = AudioDatasetLoaderPrimitive(
             hyperparams=audio_loader_hyperparams
         )
-        audio_df = audio_loader_primitive.produce(inputs=df).value
-        images.metadata = images.metadata.add_semantic_type(
-            (
-                metadata_base.ALL_ELEMENTS,
-                images.metadata.get_column_index_from_column_name("audio"),
-            ),
-            "http://schema.org/AudioObject",
-        )
+        audio_df = audio_loader_primitive.produce(inputs=dataset).value
 
         audio_transfer_hyperparams = AudioTransferPrimitive.metadata.get_hyperparams()
         primitive_volumes = AudioTransferPrimitive.metadata.get_volumes()

--- a/test/test_text_encoder.py
+++ b/test/test_text_encoder.py
@@ -43,7 +43,7 @@ class TextEncoderPrimitiveTestCase(unittest.TestCase):
         ]["Hyperparams"]
         encoder = TextEncoderPrimitive(hyperparams=hyperparams_class.defaults())
         encoder.set_training_data(
-            inputs=dataframe.iloc[:, [0, 1]], outputs=dataframe.iloc[:, 2]
+            inputs=dataframe.iloc[:, [0, 1]], outputs=dataframe[['bravo']]
         )
         encoder.fit()
         result = encoder.produce(inputs=dataframe).value
@@ -88,7 +88,7 @@ class TextEncoderPrimitiveTestCase(unittest.TestCase):
         ]["Hyperparams"]
         encoder = TextEncoderPrimitive(hyperparams=hyperparams_class.defaults())
         encoder.set_training_data(
-            inputs=dataframe.iloc[:, [0, 1]], outputs=dataframe.iloc[:, 2]
+            inputs=dataframe.iloc[:, [0, 1]], outputs=dataframe[['bravo']]
         )
         encoder.fit()
         result = encoder.produce(inputs=dataframe).value
@@ -118,7 +118,7 @@ class TextEncoderPrimitiveTestCase(unittest.TestCase):
         ]["Hyperparams"]
         encoder = TextEncoderPrimitive(hyperparams=hyperparams_class.defaults())
         encoder.set_training_data(
-            inputs=dataframe.iloc[:, [0, 1]], outputs=dataframe.iloc[:, 2]
+            inputs=dataframe.iloc[:, [0, 1]], outputs=dataframe[['bravo']]
         )
 
         # should fail in this case because we have a label with a cardinality of 1


### PR DESCRIPTION
Fixes #292 

Audio test not fully run as it requires the pretrained model. They now run to the point the model needs to exist on disk. The test dataset had to be updated to match the expected column name found in the primitive. Realistically, the primitive shouldve been designed to find the boundary columns via metadata, then fall back to a hyperparam specifying the name with a proper default. One test was update to not set the semantic type because the test is named no semantic type.

Text encoder was failing because a series was passed in for the label set rather than the expected dataframe.