### PR TITLE
Replace python-prctl with pyprctl

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,3 +1,3 @@
 nose==1.3.7
 cython>=0.29.24
-python-prctl==1.7
+pyprctl>=0.1,<0.2

--- a/distil/primitives/audio_reader.py
+++ b/distil/primitives/audio_reader.py
@@ -22,7 +22,7 @@ from typing import List, Sequence, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
-import prctl
+import pyprctl
 import soundfile as sf
 from d3m import container, utils
 from d3m.base import utils as base_utils
@@ -94,7 +94,7 @@ def convert_load_file(fileuri, start, end):
                 # Setting "pdeathsig" will make the ffmpeg process be killed if our process dies for any reason.
                 encoding="utf8",
                 check=True,
-                preexec_fn=lambda: prctl.set_pdeathsig(signal.SIGKILL),
+                preexec_fn=lambda: pyprctl.set_pdeathsig(signal.SIGKILL),
             )
         except subprocess.CalledProcessError as error:
             logger.error("Error running ffmpeg: %(stderr)s", {"stderr": error.stderr})

--- a/distil/primitives/audio_transfer.py
+++ b/distil/primitives/audio_transfer.py
@@ -81,24 +81,6 @@ class AudioTransferPrimitive(
                     "file_uri": "https://github.com/harritaylor/torchvggish/releases/download/v0.1/vggish-10086976.pth",
                     "file_digest": "10086976245803799d9194e9a73d9b6c1549c71d1b80106f5cade5608a561f4b",
                 },
-                {
-                    "type": metadata_base.PrimitiveInstallationType.UBUNTU,
-                    "package": "build-essential",
-                    "version": "12.4ubuntu1",
-                },
-                {
-                    "type": metadata_base.PrimitiveInstallationType.UBUNTU,
-                    "package": "libcap-dev",
-                    "version": "1:2.25-1.1",
-                },
-                {
-                    # "python-prctl" requires "build-essential" and "libcap-dev". We list it here instead of
-                    # "setup.py" to not have to list these system dependencies for every common primitive (because
-                    # we cannot assure this primitive annotation gets installed first).
-                    "type": metadata_base.PrimitiveInstallationType.PIP,
-                    "package": "python-prctl",
-                    "version": "1.7",
-                },
                 CYTHON_DEP,
                 {
                     "type": metadata_base.PrimitiveInstallationType.PIP,

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "sklearn_pandas @ git+https://github.com/cdbethune/sklearn-pandas.git@c009c3a5a26f883f759cf123c0f5a509b1df013b",
         "frozendict>=1.2",
         # 'nose>=1.3.7', Needs to be installed in the primitive install section
-        #'python-prctl==1.7', Needs to be installed in the primitive install section
+        'pyprctl>=0.1,<0.2',
         "fastdtw>=0.3.2",
         "resampy>=0.2.1",
         "soundfile>=0.10.2",


### PR DESCRIPTION
python-prctl is GPL and requires libpcap to be installed. pyprctl is MIT and doesn't have that requirement.

See also the same change in common-primitives in October: https://gitlab.com/datadrivendiscovery/common-primitives/-/merge_requests/157